### PR TITLE
Update otaPal_Abort and otaPal_SetPlatformImageState to pass OTA_PAL qualification test.

### DIFF
--- a/ota_pal.c
+++ b/ota_pal.c
@@ -375,11 +375,11 @@ static bool prvCheckVersion( psa_image_info_t * pActiveVersion,  psa_image_info_
 
     xActiveFirmwareVersion.u.x.major = pActiveVersion->version.iv_major;
     xActiveFirmwareVersion.u.x.minor = pActiveVersion->version.iv_minor;
-    xActiveFirmwareVersion.u.x.build = (uint16_t)pActiveVersion->version.iv_build_num;
+    xActiveFirmwareVersion.u.x.build = (uint16_t)pActiveVersion->version.iv_revision;
 
     xStageFirmwareVersion.u.x.major = pStageVersion->version.iv_major;
     xStageFirmwareVersion.u.x.minor = pStageVersion->version.iv_minor;
-    xStageFirmwareVersion.u.x.build = (uint16_t)pStageVersion->version.iv_build_num;
+    xStageFirmwareVersion.u.x.build = (uint16_t)pStageVersion->version.iv_revision;
 
     if( xActiveFirmwareVersion.u.unsignedVersion32 > xStageFirmwareVersion.u.unsignedVersion32 )
     {
@@ -412,10 +412,10 @@ bool OtaPal_ImageVersionCheck( uint32_t ulImageType )
                         ulImageType,
                         xStageImageInfo.version.iv_major,
                         xStageImageInfo.version.iv_minor,
-                        xStageImageInfo.version.iv_build_num,
+                        xStageImageInfo.version.iv_revision,
                         xActiveImageInfo.version.iv_major,
                         xActiveImageInfo.version.iv_minor,
-                        xActiveImageInfo.version.iv_build_num );
+                        xActiveImageInfo.version.iv_revision );
             }
             else
             {
@@ -423,10 +423,10 @@ bool OtaPal_ImageVersionCheck( uint32_t ulImageType )
                         ulImageType,
                         xStageImageInfo.version.iv_major,
                         xStageImageInfo.version.iv_minor,
-                        xStageImageInfo.version.iv_build_num,
+                        xStageImageInfo.version.iv_revision,
                         xActiveImageInfo.version.iv_major,
                         xActiveImageInfo.version.iv_minor,
-                        xActiveImageInfo.version.iv_build_num );
+                        xActiveImageInfo.version.iv_revision );
             }
         }
     }
@@ -449,7 +449,7 @@ bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * p
     {
         pSecureVersion->u.x.major = xImageInfo.version.iv_major;
         pSecureVersion->u.x.minor = xImageInfo.version.iv_minor;
-        pSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_build_num;
+        pSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_revision;
         xStatus = true;
     }
     else
@@ -465,7 +465,7 @@ bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * p
         {
             pNonSecureVersion->u.x.major = xImageInfo.version.iv_major;
             pNonSecureVersion->u.x.minor = xImageInfo.version.iv_minor;
-            pNonSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_build_num;
+            pNonSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_revision;
         }
         else
         {

--- a/ota_pal.c
+++ b/ota_pal.c
@@ -313,8 +313,6 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     psa_image_info_t xImageInfo = { 0 };
     psa_status_t uxStatus;
     psa_key_attributes_t xKeyAttribute = PSA_KEY_ATTRIBUTES_INIT;
-    psa_algorithm_t xKeyAlgorithm = 0;
-    bool xDecodeStatus;
 
     uxStatus = psa_fwu_query( xOTAImageID, &xImageInfo );
     if( uxStatus != PSA_SUCCESS )
@@ -328,18 +326,8 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     	return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, 0 );
     }
 
-
-    uxStatus = psa_get_key_attributes( xOTACodeVerifyKeyHandle, &xKeyAttribute );
-    if( uxStatus != PSA_SUCCESS )
-    {
-        return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, OTA_PAL_SUB_ERR( uxStatus ) );
-    }
-
-
-
-    xKeyAlgorithm = psa_get_key_algorithm( &xKeyAttribute );
     uxStatus = psa_verify_hash( xOTACodeVerifyKeyHandle,
-                                xKeyAlgorithm,
+                                PSA_ALG_ECDSA( PSA_ALG_SHA_256 ),
                                 ( const uint8_t * )xImageInfo.digest,
                                 ( size_t )PSA_FWU_MAX_DIGEST_SIZE,
 								ucECDSARAWSignature,

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -32,6 +32,7 @@
 #define OTA_PAL_H_
 
 #include "ota.h"
+#include "ota_appversion32.h"
 
 /**
  * @brief Abort an OTA transfer.
@@ -226,4 +227,24 @@ OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const pFileC
  */
 OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const pFileContext );
 
+/**
+ * @brief Get Secure and Non Secure Image versions.
+ *
+ * @param[out] pSecureVersion Pointer to secure version struct.
+ * @param[out] pNonSecureVersion Pointer to non-secure version struct.
+ *
+ * @return true if version was fetched successfully.
+ *
+ */
+bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * pNonSecureVersion );
+
+/**
+ * @brief Checks versions of an image type for rollback protection.
+ *
+ * @param[in] ulImageType Image Type for which the version needs to be checked.
+
+ * @return true if the version is higher than previous version. false otherwise.
+ *
+ */
+bool OtaPal_ImageVersionCheck( uint32_t ulImageType );
 #endif /* ifndef OTA_PAL_H_ */


### PR DESCRIPTION
Update otaPal_Abort and otaPal_SetPlatformImageState to pass OTA_PAL qualification test.

For otaPal_Abort, set pFileContext->pFile to NULL based on [definition](https://www.freertos.org/Documentation/api-ref/ota-for-aws-iot-embedded-sdk/docs/doxygen/output/html/ota__platform__interface_8h.html#ae085ba60212a4e05007c8b7fd1a77d7b).
```
The file pointer will be set to NULL after this function returns. OtaPalSuccess is returned when aborting access to the open file was successful. OtaPalFileAbort is returned when aborting access to the open file context was unsuccessful.
```

For otaPal_SetPlatformImageState, return error "OtaPalBadImageState" if eState is unknown value.