### PR TITLE
Update otaPal_Abort and otaPal_SetPlatformImageState to pass OTA_PAL qualification test.

### DIFF
--- a/ota_pal.c
+++ b/ota_pal.c
@@ -372,7 +372,7 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     
     ucSigBuffer = &ucECDSARAWSignature;
     usSigLength = ECDSA_SHA256_RAW_SIGNATURE_LENGTH;
-#endif /* defined( OTA_PAL_CODE_SIGNING_ALGO ) && ( OTA_PAL_CODE_SIGNING_ALGO == OTA_PAL_CODE_SIGNING_RSA ) */
+#endif /* !defined( OTA_PAL_SIGNATURE_ASN1_DER_FORMAT ) */
 
     uxStatus = psa_get_key_attributes( xOTACodeVerifyKeyHandle, &xKeyAttribute );
     if( uxStatus != PSA_SUCCESS )

--- a/ota_pal.c
+++ b/ota_pal.c
@@ -40,6 +40,9 @@
 
 #include "logging.h"
 
+/* To provide appFirmwareVersion for OTA library. */
+#include "ota_appversion32.h"
+
 /* OTA PAL Port include. */
 #include "ota_pal.h"
 
@@ -357,7 +360,7 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
         return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, OTA_PAL_SUB_ERR( uxStatus ) );
     }
 
-#if defined( OTA_PAL_CODE_SIGNING_ALGO ) && ( OTA_PAL_CODE_SIGNING_ALGO == OTA_PAL_CODE_SIGNING_RSA )
+#if !defined( OTA_PAL_SIGNATURE_ASN1_DER_FORMAT )
     ucSigBuffer = &pFileContext->pSignature->data;
     usSigLength = pFileContext->pSignature->size;
 #else

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -233,25 +233,4 @@ OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const pFileC
  *         error codes and your specific PAL implementation for the sub error code.
  */
 OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const pFileContext );
-
-/**
- * @brief Get Secure and Non Secure Image versions.
- *
- * @param[out] pSecureVersion Pointer to secure version struct.
- * @param[out] pNonSecureVersion Pointer to non-secure version struct.
- *
- * @return true if version was fetched successfully.
- *
- */
-bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * pNonSecureVersion );
-
-/**
- * @brief Checks versions of an image type for rollback protection.
- *
- * @param[in] ulImageType Image Type for which the version needs to be checked.
-
- * @return true if the version is higher than previous version. false otherwise.
- *
- */
-bool OtaPal_ImageVersionCheck( uint32_t ulImageType );
 #endif /* ifndef OTA_PAL_H_ */

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -34,6 +34,13 @@
 #include "ota.h"
 #include "ota_appversion32.h"
 
+/* OTA PAL configurations. */
+#define OTA_PAL_CODE_SIGNING_RSA    ( 0 )
+#define OTA_PAL_CODE_SIGNING_ECDSA  ( 1 )
+
+/* Choose code signing algorithm. */
+#define OTA_PAL_CODE_SIGNING_ALGO   ( OTA_PAL_CODE_SIGNING_ECDSA )
+
 /**
  * @brief Abort an OTA transfer.
  *

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -32,7 +32,6 @@
 #define OTA_PAL_H_
 
 #include "ota.h"
-#include "ota_appversion32.h"
 
 /* OTA PAL configurations. */
 #define OTA_PAL_CODE_SIGNING_RSA    ( 0 )
@@ -40,6 +39,9 @@
 
 /* Choose code signing algorithm. */
 #define OTA_PAL_CODE_SIGNING_ALGO   ( OTA_PAL_CODE_SIGNING_ECDSA )
+
+/* Enable to convert ASN1/DER signature to raw data. */
+#define OTA_PAL_SIGNATURE_ASN1_DER_FORMAT
 
 /**
  * @brief Abort an OTA transfer.


### PR DESCRIPTION
Update otaPal_Abort and otaPal_SetPlatformImageState to pass OTA_PAL qualification test.

For otaPal_Abort, set pFileContext->pFile to NULL based on [definition](https://www.freertos.org/Documentation/api-ref/ota-for-aws-iot-embedded-sdk/docs/doxygen/output/html/ota__platform__interface_8h.html#ae085ba60212a4e05007c8b7fd1a77d7b).

> The file pointer will be set to NULL after this function returns. OtaPalSuccess is returned
>  when aborting access to the open file was successful. OtaPalFileAbort is returned when aborting access to the open file context was unsuccessful.

For otaPal_SetPlatformImageState, return error "OtaPalBadImageState" if eState is unknown value.